### PR TITLE
Support X-GNOME-Autostart-Delay for autostart apps - Closes #3

### DIFF
--- a/gnome-session/gsm-app.c
+++ b/gnome-session/gsm-app.c
@@ -327,6 +327,7 @@ gsm_app_class_init (GsmAppClass *klass)
         klass->impl_provides = NULL;
         klass->impl_get_provides = NULL;
         klass->impl_is_running = NULL;
+        klass->impl_peek_autostart_delay = NULL;
 
         g_object_class_install_property (object_class,
                                          PROP_PHASE,
@@ -536,7 +537,22 @@ gboolean
 gsm_app_stop (GsmApp  *app,
               GError **error)
 {
-        return GSM_APP_GET_CLASS (app)->impl_stop (app, error);
+        if (gsm_app_is_running (app))
+                return GSM_APP_GET_CLASS (app)->impl_stop (app, error);
+
+        return TRUE;
+}
+
+int
+gsm_app_peek_autostart_delay (GsmApp *app)
+{
+        g_return_val_if_fail (GSM_IS_APP (app), FALSE);
+
+        if (GSM_APP_GET_CLASS (app)->impl_peek_autostart_delay) {
+                return GSM_APP_GET_CLASS (app)->impl_peek_autostart_delay (app);
+        } else {
+                return 0;
+        }
 }
 
 void

--- a/gnome-session/gsm-app.h
+++ b/gnome-session/gsm-app.h
@@ -49,6 +49,7 @@ struct _GsmAppClass
                                                        GError    **error);
         gboolean    (*impl_stop)                      (GsmApp     *app,
                                                        GError    **error);
+        int         (*impl_peek_autostart_delay)      (GsmApp     *app);
         gboolean    (*impl_provides)                  (GsmApp     *app,
                                                        const char *service);
         char **     (*impl_get_provides)              (GsmApp     *app);
@@ -109,6 +110,7 @@ gboolean         gsm_app_has_autostart_condition        (GsmApp     *app,
 gboolean         gsm_app_get_registered                 (GsmApp     *app);
 void             gsm_app_set_registered                 (GsmApp     *app,
                                                          gboolean  registered);
+int              gsm_app_peek_autostart_delay           (GsmApp     *app);
 
 gboolean         gsm_app_save_to_keyfile                (GsmApp    *app,
                                                          GKeyFile  *keyfile,

--- a/gnome-session/gsm-app.h
+++ b/gnome-session/gsm-app.h
@@ -49,7 +49,7 @@ struct _GsmAppClass
                                                        GError    **error);
         gboolean    (*impl_stop)                      (GsmApp     *app,
                                                        GError    **error);
-        int         (*impl_peek_autostart_delay)      (GsmApp     *app);
+        gint        (*impl_peek_autostart_delay)      (GsmApp     *app);
         gboolean    (*impl_provides)                  (GsmApp     *app,
                                                        const char *service);
         char **     (*impl_get_provides)              (GsmApp     *app);

--- a/gnome-session/gsm-autostart-app.h
+++ b/gnome-session/gsm-autostart-app.h
@@ -55,6 +55,7 @@ void    gsm_autostart_app_add_provides       (GsmAutostartApp *aapp,
 #define GSM_AUTOSTART_APP_DBUS_PATH_KEY   "X-GNOME-DBus-Path"
 #define GSM_AUTOSTART_APP_DBUS_ARGS_KEY   "X-GNOME-DBus-Start-Arguments"
 #define GSM_AUTOSTART_APP_DISCARD_KEY     "X-GNOME-Autostart-discard-exec"
+#define GSM_AUTOSTART_APP_DELAY_KEY       "X-GNOME-Autostart-Delay"
 
 G_END_DECLS
 

--- a/gnome-session/gsm-manager.c
+++ b/gnome-session/gsm-manager.c
@@ -757,6 +757,9 @@ on_phase_timeout (GsmManager *manager)
         return FALSE;
 }
 
+/*
+ Note - app requires to be passed by reference to be used; its cleaned up before exit
+*/
 static gboolean
 _autostart_delay_timeout (GsmApp *app)
 {
@@ -776,6 +779,7 @@ _autostart_delay_timeout (GsmApp *app)
                 }
         }
 
+        /* we unref here since we ref this on the initial call*/
         g_object_unref (app);
 
         return FALSE;

--- a/gnome-session/gsm-manager.c
+++ b/gnome-session/gsm-manager.c
@@ -416,7 +416,8 @@ app_condition_changed (GsmApp     *app,
                 } else {
                         g_debug ("GsmManager: stopping app %s", gsm_app_peek_id (app));
 
-                        /* If we don't have a client then we should try to kill the app */
+                        /* If we don't have a client then we should try to kill the app ,
+                         * if it is running */
                         error = NULL;
                         res = gsm_app_stop (app, &error);
                         if (! res) {
@@ -757,10 +758,35 @@ on_phase_timeout (GsmManager *manager)
 }
 
 static gboolean
+_autostart_delay_timeout (GsmApp *app)
+{
+        GError *error = NULL;
+        gboolean res;
+
+        if (!gsm_app_peek_is_disabled (app)
+            && !gsm_app_peek_is_conditionally_disabled (app)) {
+                res = gsm_app_start (app, &error);
+                if (!res) {
+                        if (error != NULL) {
+                                g_warning ("Could not launch application '%s': %s",
+                                           gsm_app_peek_app_id (app),
+                                           error->message);
+                                g_error_free (error);
+                        }
+                }
+        }
+
+        g_object_unref (app);
+
+        return FALSE;
+}
+
+static gboolean
 _start_app (const char *id,
             GsmApp     *app,
             GsmManager *manager)
 {
+        int delay;
         GsmManagerPrivate *priv = gsm_manager_get_instance_private (manager);
 
         if (gsm_app_peek_phase (app) != priv->phase) {
@@ -778,6 +804,18 @@ _start_app (const char *id,
             || gsm_app_peek_is_conditionally_disabled (app)) {
                 g_debug ("GsmManager: Skipping disabled app: %s", id);
                 goto out;
+        }
+
+        /* Only accept an autostart delay for the application phase */
+        if (priv->phase == GSM_MANAGER_PHASE_APPLICATION) {
+                delay = gsm_app_peek_autostart_delay (app);
+                if (delay > 0) {
+                        g_timeout_add_seconds (delay,
+                                               (GSourceFunc)_autostart_delay_timeout,
+                                               g_object_ref (app));
+                        g_debug ("GsmManager: %s is scheduled to start in %d seconds", id, delay);
+                        goto out;
+                }
         }
 
         if (!start_app_or_warn (manager, app))
@@ -1465,11 +1503,12 @@ _debug_app_for_phase (const char *id,
                 return FALSE;
         }
 
-        g_debug ("GsmManager:\tID: %s\tapp-id:%s\tis-disabled:%d\tis-conditionally-disabled:%d",
+        g_debug ("GsmManager:\tID: %s\tapp-id:%s\tis-disabled:%d\tis-conditionally-disabled:%d\tis-delayed:%d",
                  gsm_app_peek_id (app),
                  gsm_app_peek_app_id (app),
                  gsm_app_peek_is_disabled (app),
-                 gsm_app_peek_is_conditionally_disabled (app));
+                 gsm_app_peek_is_conditionally_disabled (app),
+                 (gsm_app_peek_autostart_delay (app) > 0));
 
         return FALSE;
 }


### PR DESCRIPTION
As per the linked issue - this supports the X-GNOME-Autostart-Delay key for autostarting apps in the same way as cinnamon-session, mate-session and ubuntu's gnome-session.