### PR TITLE
Lets make friends with the Qt ecosystem

### DIFF
--- a/gnome-session/main.c
+++ b/gnome-session/main.c
@@ -617,9 +617,31 @@ main (int argc, char **argv)
 
         /*
          * If not set, define the platform compatibility for QT apps
-        */
+         */
         if (g_getenv ("QT_QPA_PLATFORMTHEME") == NULL) {
             g_setenv("QT_QPA_PLATFORMTHEME", "gtk3", TRUE);
+        }
+
+        /*
+         * If not set, define QT Quick Controls compatibility
+         * distros need to ship the equivalent qqc2-desktop-style
+         * package to make use of this
+         */
+        if (g_getenv ("QT_QUICK_CONTROLS_STYLE") == NULL) {
+            g_setenv("QT_QUICK_CONTROLS_STYLE", "org.kde.desktop", TRUE);
+        }
+
+        /*
+         * If kvantum has been installed we assume that the override
+         * environment variable should be set to make use of it - assuming it
+         * hasn't already been defined
+         */
+        gchar *kvantum_path = g_find_program_in_path("kvantummanager");
+        if (kvantum_path) {
+            if (g_getenv ("QT_STYLE_OVERRIDE") == NULL) {
+                g_setenv("QT_STYLE_OVERRIDE", "kvantum", TRUE);
+            }
+            g_free (kvantum_path);
         }
 
         /* Talk to logind before acquiring a name, since it does synchronous

--- a/gnome-session/main.c
+++ b/gnome-session/main.c
@@ -428,8 +428,8 @@ main (int argc, char **argv)
          * set a fallback value if we don't find it set.
          */
         if (g_getenv ("XDG_CURRENT_DESKTOP") == NULL) {
-            g_setenv("XDG_CURRENT_DESKTOP", "GNOME", TRUE);
-            gsm_util_setenv ("XDG_CURRENT_DESKTOP", "GNOME");
+            g_setenv("XDG_CURRENT_DESKTOP", "BUDGIE", TRUE);
+            gsm_util_setenv ("XDG_CURRENT_DESKTOP", "BUDGIE");
         }
 
         /* Make sure we initialize gio in a way that does not autostart any daemon */
@@ -614,6 +614,13 @@ main (int argc, char **argv)
         /* We want to use the GNOME menus which has the designed categories.
          */
         gsm_util_setenv ("XDG_MENU_PREFIX", "gnome-");
+
+        /*
+         * If not set, define the platform compatibility for QT apps
+        */
+        if (g_getenv ("QT_QPA_PLATFORMTHEME") == NULL) {
+            g_setenv("QT_QPA_PLATFORMTHEME", "gtk3", TRUE);
+        }
 
         /* Talk to logind before acquiring a name, since it does synchronous
          * calls at initialization time that invoke a main loop and if we


### PR DESCRIPTION
This PR adds three session based environment variables so that out-of-the-box Qt based apps can be styled with the default GTK3 theme - unless obviously a Qt app quite rightly decides to take styling under its own control.

So we automatically add the environment vars for QT Quick Controls aka kirigami based QT apps as well as the helper var QT_QPA_PLATFORMTHEME.

We also set the var for kvantum - but only if kvantum  has been installed - i.e. if the user (or distro) has explicitly decided to style via the kvantum engine.

Since these are environment vars - little risk to any other app type - and anyway environment vars can be overridden by the user  or explicitly if set via environment/profile.

----

We also fix a potential bug if the user isn't using a login manager / or not using /usr/bin/budgie desktop - we define XDG_CURRENT_DESKTOP to be "Budgie" which would normally be set via the session desktop file.