### PR TITLE
budgie-desktop Autostartfolder

### DIFF
--- a/gnome-session/gsm-util.c
+++ b/gnome-session/gsm-util.c
@@ -248,7 +248,7 @@ gsm_util_get_standard_autostart_dirs (void)
         for (i = 0; system_data_dirs[i]; i++) {
                 g_ptr_array_add (dirs,
                                  g_build_filename (system_data_dirs[i],
-                                                   "gnome", "autostart", NULL));
+                                                   "budgie-desktop", "autostart", NULL));
         }
 
         system_config_dirs = g_get_system_config_dirs ();

--- a/scripts/mkRelease.sh
+++ b/scripts/mkRelease.sh
@@ -11,5 +11,5 @@ VTAR="budgie-session-v${VERSION}.tar.xz"
 
 mv build/meson-dist/$TAR $VTAR
 
-gpg --armor --detach-sign --local-use 0x1E1FB0017C998A8AE2C498A6C2EAA8A26ADC59EE $VTAR
+gpg --armor --detach-sign $VTAR
 gpg --verify "${VTAR}.asc"

--- a/scripts/mkRelease.sh
+++ b/scripts/mkRelease.sh
@@ -11,5 +11,5 @@ VTAR="budgie-session-v${VERSION}.tar.xz"
 
 mv build/meson-dist/$TAR $VTAR
 
-gpg --armor --detach-sign $VTAR
+gpg --armor --detach-sign --local-use 0x1E1FB0017C998A8AE2C498A6C2EAA8A26ADC59EE $VTAR
 gpg --verify "${VTAR}.asc"


### PR DESCRIPTION
When looking for the session autostart folders, budgie-session currently looks for autostart .desktop files in this order

    .config/xdg/autostart
    /usr/share/gnome/autostart
    /etc/xdg/autostart

The middle one is a legacy of our fork.  This PR corrects this so that the folder it looks at is /usr/share/budgie-desktop/autostart

This allow packagers to override autostart files shipped by a vendor by placing the same name .desktop file in /usr/share/budgie-desktop/autostart rather than patching the package itself.

For UB we need to stop the X11 based /etc/xdg/autostart/blueman.desktop from autostarting - this causes crash dumps - and we don't have the ability to override the package /etc/xdg/autostart desktop file since that will impact XFCE/MATE etc.